### PR TITLE
Documentation: Union Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 [PR #47](https://github.com/fivetran/dbt_amazon_ads/pull/47) includes the following updates:
 
 ## Schema/Data Changes
-**3 total changes • 2 possible breaking changes**
+**2 total changes • 1 possible breaking change**
 
 | Data Model(s) | Change type | Old | New | Notes |
 | ------------- | ----------- | --- | --- | ----- |
-| All models | Single-connection `source_relation` value | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>` | Powered by the new `fivetran_utils.apply_source_relation` macro. |
-| All models | `source_relation` value for `amazon_ads_sources` users | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>` | Introduces the `amazon_ads_sources` variable to union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details. |
-| All models | `source_relation` value for legacy `amazon_ads_union_schemas` / `amazon_ads_union_databases` users | Schema or database name (e.g. `my_schema`) | Empty string (`''`) | `fivetran_utils.apply_source_relation` calls `source_relation()` without package-specific variable arguments, so the legacy union variables no longer populate `source_relation`. We recommend migrating to `amazon_ads_sources` for meaningful `source_relation` values. |
+| All models | Single-connection `source_relation` value | Empty string (`''`) | `<database>.<schema>` | Values are derived from the `amazon_ads_database` and `amazon_ads_schema` variables (or their defaults). Powered by the new `fivetran_utils.apply_source_relation` macro. |
+| All models | `source_relation` value for `amazon_ads_sources` users | Empty string (`''`) | `<database>.<schema>` | Values are derived from each entry's `database` and `schema` fields in `amazon_ads_sources`. Introduces the `amazon_ads_sources` variable to union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details. |
 
 ## Under the Hood
 - Adds the `fivetran_using_source_casing` variable for case-sensitive destination support. When enabled, downstream transformations respect source casing to ensure consistent results. See the [Additional Configurations](https://github.com/fivetran/dbt_amazon_ads/#source-casing-for-case-sensitive-destinations) section of the README for details. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
   - If you reference `fivetran/amazon_ads_source` in your `packages.yml`, you must remove this dependency to avoid conflicts.
   - Any source overrides referencing the `fivetran/amazon_ads_source` package will also need to be removed or updated to reference this package.
   - Update any amazon_ads_source-scoped variables to be scoped to only under this package. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md) for how to configure the build schema of staging models.
-- As part of theconfigurations consolidation, vars are no longer used to reference staging models, and only sources are represented by vars. Staging models are now referenced directly with `ref()` in downstream models.
+- As part of the consolidation, vars are no longer used to reference staging models, and only sources are represented by vars. Staging models are now referenced directly with `ref()` in downstream models.
 
 
 ### dbt Fusion Compatibility Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,9 @@
 - Introduces the `amazon_ads_sources` variable, which lets you union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details.
   - The old `amazon_ads_union_schemas` and `amazon_ads_union_databases` variables remain supported for backward compatibility.
 
-
 ## Under the Hood
 - Adds the `fivetran_using_source_casing` variable for case-sensitive destination support. When enabled, downstream transformations respect source casing to ensure consistent results. See the [Additional Configurations](https://github.com/fivetran/dbt_amazon_ads/#source-casing-for-case-sensitive-destinations) section of the README for details. 
-- Introduces `fivetran_utils.partition_by_source_relation` for partitioning by source model across staging models.
+- Introduces `fivetran_utils.partition_by_source_relation` to conditionally include `source_relation` in partition clauses only when multiple sources are configured.
 
 # dbt_amazon_ads v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 [PR #47](https://github.com/fivetran/dbt_amazon_ads/pull/47) includes the following updates:
 
-## Schema/Data Changes
+## Schema/Data Changes (--full-refresh required after upgrading)
 **2 total changes • 1 possible breaking change**
 
 | Data Model(s) | Change type | Old | New | Notes |
 | ------------- | ----------- | --- | --- | ----- |
-| All models | Single-connection `source_relation` value | Empty string (`''`) | `<database>.<schema>` | Values are derived from the `amazon_ads_database` and `amazon_ads_schema` variables (or their defaults). Powered by the new `fivetran_utils.apply_source_relation` macro. |
-| All models | `source_relation` value for `amazon_ads_sources` users | Empty string (`''`) | `<database>.<schema>` | Values are derived from each entry's `database` and `schema` fields in `amazon_ads_sources`. Introduces the `amazon_ads_sources` variable to union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details. |
+| All models | `source_relation` column (when using a single Amazon Ads schema) | Empty string (`''`) | `<database>.<schema>` |  |
+
+## Feature Updates
+- Introduces the new (recommended) `amazon_ads_sources` variable for more robust union data configuration. The old `amazon_ads_union_schemas` and `amazon_ads_union_databases` variables will still be supported. See the [README](https://github.com/fivetran/dbt_amazon_ads/tree/main#define-database-and-schema-variables) for specific details. 
 
 ## Under the Hood
 - Adds the `fivetran_using_source_casing` variable for case-sensitive destination support. When enabled, downstream transformations respect source casing to ensure consistent results. See the [Additional Configurations](https://github.com/fivetran/dbt_amazon_ads/#source-casing-for-case-sensitive-destinations) section of the README for details. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # dbt_amazon_ads v1.3.0
 
-TBD
+[PR #47](https://github.com/fivetran/dbt_amazon_ads/pull/47) includes the following updates:
+
+## Schema/Data Change
+**1 total change • 1 possible breaking change**
+
+| Data Model(s) | Change type | Old | New | Notes |
+| ------------- | ----------- | --- | --- | ----- |
+| All models | Single-connection `source_relation` value | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>` | Powered by the new `fivetran_utils.apply_source_relation` macro |
+
+## Feature Update
+- Introduces the `amazon_ads_sources` variable, which lets you union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details.
+  - The old `amazon_ads_union_schemas` and `amazon_ads_union_databases` variables remain supported for backward compatibility.
+
+
+## Under the Hood
+- Adds the `fivetran_using_source_casing` variable for case-sensitive destination support. When enabled, downstream transformations respect source casing to ensure consistent results. See the [Additional Configurations](https://github.com/fivetran/dbt_amazon_ads/#source-casing-for-case-sensitive-destinations) section of the README for details. 
+- Introduces `fivetran_utils.partition_by_source_relation` for partitioning by source model across staging models.
 
 # dbt_amazon_ads v1.2.0
 
@@ -33,7 +49,7 @@ TBD
   - If you reference `fivetran/amazon_ads_source` in your `packages.yml`, you must remove this dependency to avoid conflicts.
   - Any source overrides referencing the `fivetran/amazon_ads_source` package will also need to be removed or updated to reference this package.
   - Update any amazon_ads_source-scoped variables to be scoped to only under this package. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md) for how to configure the build schema of staging models.
-- As part of the consolidation, vars are no longer used to reference staging models, and only sources are represented by vars. Staging models are now referenced directly with `ref()` in downstream models.
+- As part of theconfigurations consolidation, vars are no longer used to reference staging models, and only sources are represented by vars. Staging models are now referenced directly with `ref()` in downstream models.
 
 
 ### dbt Fusion Compatibility Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,12 @@
 [PR #47](https://github.com/fivetran/dbt_amazon_ads/pull/47) includes the following updates:
 
 ## Schema/Data Change
-**1 total change • 1 possible breaking change**
+**2 total changes • 1 possible breaking change**
 
 | Data Model(s) | Change type | Old | New | Notes |
 | ------------- | ----------- | --- | --- | ----- |
-| All models | Single-connection `source_relation` value | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>` | Powered by the new `fivetran_utils.apply_source_relation` macro |
-
-## Feature Update
-- Introduces the `amazon_ads_sources` variable, which lets you union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details.
-  - The old `amazon_ads_union_schemas` and `amazon_ads_union_databases` variables remain supported for backward compatibility.
+| All models | Single-connection `source_relation` value | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>` | Powered by the new `fivetran_utils.apply_source_relation` macro. |
+| All models | `source_relation` value for `amazon_ads_sources` users | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>.<table_name>` | Introduces the `amazon_ads_sources` variable to union multiple Amazon Ads connections simultaneously. The legacy `amazon_ads_union_schemas` and `amazon_ads_union_databases` variables remain supported. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details. |
 
 ## Under the Hood
 - Adds the `fivetran_using_source_casing` variable for case-sensitive destination support. When enabled, downstream transformations respect source casing to ensure consistent results. See the [Additional Configurations](https://github.com/fivetran/dbt_amazon_ads/#source-casing-for-case-sensitive-destinations) section of the README for details. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 [PR #47](https://github.com/fivetran/dbt_amazon_ads/pull/47) includes the following updates:
 
-## Schema/Data Change
-**2 total changes • 1 possible breaking change**
+## Schema/Data Changes
+**3 total changes • 2 possible breaking changes**
 
 | Data Model(s) | Change type | Old | New | Notes |
 | ------------- | ----------- | --- | --- | ----- |
 | All models | Single-connection `source_relation` value | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>` | Powered by the new `fivetran_utils.apply_source_relation` macro. |
-| All models | `source_relation` value for `amazon_ads_sources` users | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>.<table_name>` | Introduces the `amazon_ads_sources` variable to union multiple Amazon Ads connections simultaneously. The legacy `amazon_ads_union_schemas` and `amazon_ads_union_databases` variables remain supported. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details. |
+| All models | `source_relation` value for `amazon_ads_sources` users | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>.<table_name>` | Introduces the `amazon_ads_sources` variable to union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details. |
+| All models | `source_relation` value for legacy `amazon_ads_union_schemas` / `amazon_ads_union_databases` users | Schema or database name (e.g. `my_schema`) | Empty string (`''`) | `fivetran_utils.apply_source_relation` calls `source_relation()` without package-specific variable arguments, so the legacy union variables no longer populate `source_relation`. We recommend migrating to `amazon_ads_sources` for meaningful `source_relation` values. |
 
 ## Under the Hood
 - Adds the `fivetran_using_source_casing` variable for case-sensitive destination support. When enabled, downstream transformations respect source casing to ensure consistent results. See the [Additional Configurations](https://github.com/fivetran/dbt_amazon_ads/#source-casing-for-case-sensitive-destinations) section of the README for details. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 | Data Model(s) | Change type | Old | New | Notes |
 | ------------- | ----------- | --- | --- | ----- |
 | All models | Single-connection `source_relation` value | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>` | Powered by the new `fivetran_utils.apply_source_relation` macro. |
-| All models | `source_relation` value for `amazon_ads_sources` users | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>.<table_name>` | Introduces the `amazon_ads_sources` variable to union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details. |
+| All models | `source_relation` value for `amazon_ads_sources` users | Empty string (`''`) | `<amazon_ads_database>.<amazon_ads_schema>` | Introduces the `amazon_ads_sources` variable to union multiple Amazon Ads connections simultaneously. See the [README](https://github.com/fivetran/dbt_amazon_ads/blob/main/README.md#option-b-union-multiple-connections) for setup details. |
 | All models | `source_relation` value for legacy `amazon_ads_union_schemas` / `amazon_ads_union_databases` users | Schema or database name (e.g. `my_schema`) | Empty string (`''`) | `fivetran_utils.apply_source_relation` calls `source_relation()` without package-specific variable arguments, so the legacy union variables no longer populate `source_relation`. We recommend migrating to `amazon_ads_sources` for meaningful `source_relation` values. |
 
 ## Under the Hood

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Include the following amazon_ads package version in your `packages.yml` file _if
 ```yaml
 packages:
   - package: fivetran/amazon_ads
-    version: [">=1.2.0", "<1.3.0"] # we recommend using ranges to capture non-breaking changes automatically
+    version: [">=1.3.0", "<1.4.0"] # we recommend using ranges to capture non-breaking changes automatically
 ```
 
 > All required sources and staging models are now bundled into this transformation package. Do not include `fivetran/amazon_ads_source` in your `packages.yml` since this package has been deprecated.
@@ -178,6 +178,14 @@ If an individual source table has a different name than the package expects, add
 ```yml
 vars:
     amazon_ads_<default_source_table_name>_identifier: your_table_name 
+```
+
+#### Source casing for case-sensitive destinations
+By default, the package applies case-insensitive comparisons when resolving `source_relation` values. If your destination is case-sensitive and you want downstream transformations to respect the exact casing of your source database and schema names, set the following variable:
+
+```yml
+vars:
+    fivetran_using_source_casing: true
 ```
 
 </details>

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'amazon_ads_integration_tests'
-version: '1.2.0'
+version: '1.3.0'
 
 profile: 'integration_tests' 
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'amazon_ads_integration_tests'
-version: '1.3.0'
+version: '1.2.0'
 
 profile: 'integration_tests' 
 
@@ -39,7 +39,7 @@ dispatch:
 seeds:
   +docs:
     show: False
-  +quote_columns: "{{ target.type == 'redshift' or not var('using_deliberate_quoting', true) }}"
+  +quote_columns: "{{ true if target.type == 'redshift' else false }}"
   amazon_ads_integration_tests:
     ad_group_level_report_data:
       +column_types:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -39,7 +39,7 @@ dispatch:
 seeds:
   +docs:
     show: False
-  +quote_columns: "{{ true if target.type == 'redshift' else false }}"
+  +quote_columns: "{{ target.type == 'redshift' or not var('using_deliberate_quoting', true) }}"
   amazon_ads_integration_tests:
     ad_group_level_report_data:
       +column_types:


### PR DESCRIPTION
CHANGELOG and README updates for New Union updates for Amazon Ads. Also should template all packages with old union data setup for release automation.